### PR TITLE
Fix the timestamp in High Sierra

### DIFF
--- a/backUpMessages.sh
+++ b/backUpMessages.sh
@@ -23,7 +23,7 @@ mkdir $contactNumber
 cd $contactNumber
 #Perform SQL operations
 sqlite3 ~/Library/Messages/chat.db "
-select is_from_me,text, datetime(date + strftime('%s', '2001-01-01 00:00:00'), 'unixepoch', 'localtime') as date from message where handle_id=(
+select is_from_me,text, datetime((date / 1000000000) + strftime('%s', '2001-01-01 00:00:00'), 'unixepoch', 'localtime') as date from message where handle_id=(
 select handle_id from chat_handle_join where chat_id=(
 select ROWID from chat where guid='$line')
 )" | sed 's/1\|/Me: /g;s/0\|/Friend: /g' > $line.txt


### PR DESCRIPTION
It seems, at least in macOS High Sierra that dates have increased in size by a factor of 10.

For example: 

- 2017-10-18 10:29:34, is now stored as 530011774000000000.
- To get the true time, you need to divide by 1000000000
 - And then add 2001-01-01 in UNIX time (978307200).

i.e.

- 530011774000000000 / 1000000000 = 530011774
- 530011774 + 978307200 = 1508318974
- 1508318974 => Wednesday, 18 October 2017 09:29:34

Fixes https://github.com/PeterKaminski09/baskup/issues/15.
Perhaps this change should be scoped to only High Sierra by detecting the version of macOS?